### PR TITLE
Persist PullRequests

### DIFF
--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -11,14 +11,14 @@ class HooksController < ApplicationController
       opened
     end
 
-    persist_pr
+    persist_pull_request
 
     render json: true
   end
 
   private
 
-  def persist_pr
+  def persist_pull_request
     pr = PullRequest.find_or_initialize_by(github_id: pull_request.id)
     pr.update(
       github_state: pull_request.state,

--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -11,10 +11,25 @@ class HooksController < ApplicationController
       opened
     end
 
+    persist_pr
+
     render json: true
   end
 
   private
+
+  def persist_pr
+    pr = PullRequest.find_or_initialize_by(github_id: pull_request.id)
+    pr.update(
+      github_state: pull_request.state,
+      github_user_name: pull_request.user_nickname,
+      title: pull_request.title,
+      html_url: pull_request.html_url,
+      body: pull_request.body,
+      github_created_at: pull_request.created_at,
+      github_updated_at: pull_request.updated_at
+    )
+  end
 
   def project
     @project ||= Project.find(params[:project_id])

--- a/app/models/git/pull_request.rb
+++ b/app/models/git/pull_request.rb
@@ -1,6 +1,6 @@
 module Git
   class PullRequest
-    API_FIELDS = [:id, :number, :merged_at, :body, :title, :html_url, :state]
+    API_FIELDS = [:id, :number, :merged_at, :body, :title, :html_url, :state, :created_at, :updated_at]
     JSON_FIELDS = [:id, :number, :merged_at, :title, :html_url, :state]
 
     attr_accessor *API_FIELDS, :repository, :has_note

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -1,0 +1,2 @@
+class PullRequest < ActiveRecord::Base
+end

--- a/db/migrate/20150716201757_create_pull_requests.rb
+++ b/db/migrate/20150716201757_create_pull_requests.rb
@@ -1,0 +1,16 @@
+class CreatePullRequests < ActiveRecord::Migration
+  def change
+    create_table :pull_requests do |t|
+      t.integer :github_id, null: false
+      t.string :github_state, null: false
+      t.string :title, null: false
+      t.string :html_url, null: false
+      t.string :body, null: false
+      t.string :github_user_name, null: false
+
+      t.datetime :github_created_at, null: false
+      t.datetime :github_updated_at, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150618193455) do
+ActiveRecord::Schema.define(version: 20150716201757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,6 +95,19 @@ ActiveRecord::Schema.define(version: 20150618193455) do
 
   add_index "projects_reviewers", ["project_id"], name: "index_projects_reviewers_on_project_id", using: :btree
   add_index "projects_reviewers", ["reviewer_id"], name: "index_projects_reviewers_on_reviewer_id", using: :btree
+
+  create_table "pull_requests", force: :cascade do |t|
+    t.integer  "github_id",         null: false
+    t.string   "github_state",      null: false
+    t.string   "title",             null: false
+    t.string   "html_url",          null: false
+    t.string   "body",              null: false
+    t.string   "github_user_name",  null: false
+    t.datetime "github_created_at", null: false
+    t.datetime "github_updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "reports", force: :cascade do |t|
     t.string   "name",       limit: 255,                 null: false

--- a/spec/factories/pull_request.rb
+++ b/spec/factories/pull_request.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :pull_request do
+    github_id 1
+    github_state 'open'
+    title { 'test' }
+    html_url { 'test' }
+    github_user_name 'sb8244'
+    body { 'test' }
+    github_created_at { 1.day.ago }
+    github_updated_at { Time.now }
+  end
+end


### PR DESCRIPTION
# New Feature - Persist PullRequests to Database

Persist key attributes of a pull request to the database.