### PR TITLE
Render Project Note as HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This project is provided under the MIT License, see LICENSE for a copy.
 ## In Due Time
 
 * [X] Emails for a user are customizable
-* [ ] Releases are in an rss feed
+* [X] Releases are in an rss feed
 * [X] Releases are in beautiful 1 page format
 * [ ] Reviewers are in groups and groups can be notified in the workflow
 * [ ] Workflow editor that triggers on different events

--- a/app/views/public/notes/rss.xml.builder
+++ b/app/views/public/notes/rss.xml.builder
@@ -8,7 +8,7 @@ xml.rss version: '2.0' do
     @notes.each do |note|
       next unless note.published?
       xml.item do
-        xml.title note.title
+        xml.title note.html_title
         xml.description note.html_body
         xml.pubDate note.published_at.rfc822
       end

--- a/spec/controllers/public/notes_controller_spec.rb
+++ b/spec/controllers/public/notes_controller_spec.rb
@@ -73,7 +73,18 @@ RSpec.describe Public::NotesController, :type => :controller do
       expect(response.body).to include("<title>#{project.title}</title>")
     end
 
-    it 'includes the notes text' do
+    it 'includes the notes title' do
+      [note1, note2, note3].each do |note|
+        expect(response.body).to include("<title>#{CGI::escapeHTML(note.html_title)}</title>")
+      end
+    end
+
+    it 'renders note markdown as html' do
+      note1.update!(title: '*Title*')
+      expect(response.body).to_not include("*Title*")
+    end
+
+    it 'includes the notes body' do
       [note1, note2, note3].each do |note|
         expect(response.body).to include("<description>#{CGI::escapeHTML(note.html_body)}</description>")
       end


### PR DESCRIPTION
# Bug - Display Project Note titles as html

Previously any markdown titles would be displayed in markdown format. Now we render the titles with the markdown rendered to HTML.

