### PR TITLE
Api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'pg'
 gem 'active_model_serializers', '~> 0.9.3'
 gem 'friendly_id'
 gem 'responders', '~> 2.0'
+gem 'kaminari'
 
 # users
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,9 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.2)
     jwt (1.2.0)
+    kaminari (0.16.3)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     libv8 (3.16.14.7)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
@@ -270,6 +273,7 @@ DEPENDENCIES
   friendly_id
   github-markup
   jquery-rails
+  kaminari
   newrelic_rpm
   nokogiri
   octokit (~> 3.0)
@@ -295,4 +299,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.4
+   1.11.2

--- a/app/controllers/site/base_controller.rb
+++ b/app/controllers/site/base_controller.rb
@@ -1,0 +1,15 @@
+class Site::BaseController < ApplicationController
+  skip_before_filter :verify_authenticity_token
+  skip_before_filter :check_for_invite
+  respond_to :json
+
+  def project
+    @project ||= Project.find(params.fetch(:site_id))
+  end
+
+  before_filter :set_format
+
+  def set_format
+    request.format = :json
+  end
+end

--- a/app/controllers/site/published_notes_controller.rb
+++ b/app/controllers/site/published_notes_controller.rb
@@ -1,9 +1,15 @@
 class Site::PublishedNotesController < Site::BaseController
+  PER_PAGE = 10
+
   def index
-    respond_with :site, published_notes, each_serializer: SiteApi::NoteSerializer
+    respond_with :site, published_notes.page(page).per(PER_PAGE), each_serializer: SiteApi::NoteSerializer
   end
 
   private
+
+  def page
+    params.fetch(:page, 1)
+  end
 
   def published_notes
     project.notes.published_filtered.order(published_at: :desc, id: :desc)

--- a/app/controllers/site/published_notes_controller.rb
+++ b/app/controllers/site/published_notes_controller.rb
@@ -2,7 +2,8 @@ class Site::PublishedNotesController < Site::BaseController
   PER_PAGE = 10
 
   def index
-    respond_with :site, published_notes.page(page).per(PER_PAGE), each_serializer: SiteApi::NoteSerializer
+    update_user_reading_location(paged_notes.first) if user_key
+    respond_with :site, paged_notes, each_serializer: SiteApi::NoteSerializer
   end
 
   private
@@ -13,5 +14,26 @@ class Site::PublishedNotesController < Site::BaseController
 
   def published_notes
     project.notes.published_filtered.order(published_at: :desc, id: :desc)
+  end
+
+  def paged_notes
+    @paged_notes ||= published_notes.page(page).per(PER_PAGE).to_a
+  end
+
+  def user_key
+    params[:user_key]
+  end
+
+  def update_user_reading_location(note)
+    new_location = note.published_at || Time.current
+
+    if user_reading_location.reading_location.blank? || new_location > user_reading_location.reading_location
+      user_reading_location.reading_location = new_location
+      user_reading_location.save
+    end
+  end
+
+  def user_reading_location
+    @user_reading_location ||= project.user_reading_locations.where(user_key: user_key).first_or_initialize
   end
 end

--- a/app/controllers/site/published_notes_controller.rb
+++ b/app/controllers/site/published_notes_controller.rb
@@ -3,7 +3,7 @@ class Site::PublishedNotesController < Site::BaseController
 
   def index
     update_user_reading_location(paged_notes.first) if user_key
-    respond_with :site, paged_notes, each_serializer: SiteApi::NoteSerializer, root: "notes"
+    respond_with :site, paged_notes, each_serializer: SiteApi::NoteSerializer, root: "notes", meta: paged_meta
   end
 
   private
@@ -17,7 +17,15 @@ class Site::PublishedNotesController < Site::BaseController
   end
 
   def paged_notes
-    @paged_notes ||= published_notes.page(page).per(PER_PAGE).to_a
+    @paged_notes ||= published_notes.page(page).per(PER_PAGE)
+  end
+
+  def paged_meta
+    {
+      total_count: paged_notes.total_count,
+      total_pages: paged_notes.total_pages,
+      page: page
+    }
   end
 
   def user_key

--- a/app/controllers/site/published_notes_controller.rb
+++ b/app/controllers/site/published_notes_controller.rb
@@ -6,6 +6,10 @@ class Site::PublishedNotesController < Site::BaseController
     respond_with :site, paged_notes, each_serializer: SiteApi::NoteSerializer, root: "notes", meta: paged_meta
   end
 
+  def unread
+    render json: { unread: unread_count }
+  end
+
   private
 
   def page
@@ -43,5 +47,13 @@ class Site::PublishedNotesController < Site::BaseController
 
   def user_reading_location
     @user_reading_location ||= project.user_reading_locations.where(user_key: user_key).first_or_initialize
+  end
+
+  def unread_count
+    if user_reading_location.reading_location.blank?
+      count = published_notes.count
+    else
+      count = published_notes.where("published_at > ?", user_reading_location.reading_location).count
+    end
   end
 end

--- a/app/controllers/site/published_notes_controller.rb
+++ b/app/controllers/site/published_notes_controller.rb
@@ -3,7 +3,7 @@ class Site::PublishedNotesController < Site::BaseController
 
   def index
     update_user_reading_location(paged_notes.first) if user_key
-    respond_with :site, paged_notes, each_serializer: SiteApi::NoteSerializer
+    respond_with :site, paged_notes, each_serializer: SiteApi::NoteSerializer, root: "notes"
   end
 
   private

--- a/app/controllers/site/published_notes_controller.rb
+++ b/app/controllers/site/published_notes_controller.rb
@@ -1,0 +1,11 @@
+class Site::PublishedNotesController < Site::BaseController
+  def index
+    respond_with :site, published_notes, each_serializer: SiteApi::NoteSerializer
+  end
+
+  private
+
+  def published_notes
+    project.notes.published_filtered.order(published_at: :desc, id: :desc)
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,6 +6,7 @@ class Project < ActiveRecord::Base
   has_many :reports
   has_many :converted_pull_requests
   has_and_belongs_to_many :reviewers
+  has_many :user_reading_locations
 
   before_create :create_secret_token
 

--- a/app/models/user_reading_location.rb
+++ b/app/models/user_reading_location.rb
@@ -1,0 +1,3 @@
+class UserReadingLocation < ActiveRecord::Base
+  belongs_to :project
+end

--- a/app/serializers/site_api/note_serializer.rb
+++ b/app/serializers/site_api/note_serializer.rb
@@ -1,0 +1,7 @@
+class SiteApi::NoteSerializer < ActiveModel::Serializer
+  attributes :id, :html_title, :html_body, :published_at
+
+  def published_at
+    object.published_at.try!(:to_s, :db)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,11 @@ Rails.application.routes.draw do
   get '/auth/:provider/callback', to: 'oauth_callbacks#create'
 
   resources :sites, only: [], module: "site" do
-    resources :published_notes, only: [:index]
+    resources :published_notes, only: [:index] do
+      collection do
+        get :unread
+      end
+    end
   end
 
   namespace :api do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,10 @@ Rails.application.routes.draw do
   get '/auth/:provider', to: lambda{|env| [404, {}, ["Not Found"]]}, as: 'auth'
   get '/auth/:provider/callback', to: 'oauth_callbacks#create'
 
+  resources :sites, only: [], module: "site" do
+    resources :published_notes, only: [:index]
+  end
+
   namespace :api do
     resources :projects do
       resources :hooks

--- a/db/migrate/20160423174010_create_user_reading_locations.rb
+++ b/db/migrate/20160423174010_create_user_reading_locations.rb
@@ -1,0 +1,13 @@
+class CreateUserReadingLocations < ActiveRecord::Migration
+  def change
+    create_table :user_reading_locations do |t|
+      t.string :user_key, null: false
+      t.datetime :reading_location, null: false
+      t.belongs_to :project, index: true, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :user_reading_locations, [:user_key, :project_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160422023129) do
+ActiveRecord::Schema.define(version: 20160423174010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -155,6 +155,17 @@ ActiveRecord::Schema.define(version: 20160422023129) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "user_reading_locations", force: :cascade do |t|
+    t.string   "user_key",         null: false
+    t.datetime "reading_location", null: false
+    t.integer  "project_id",       null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+  end
+
+  add_index "user_reading_locations", ["project_id"], name: "index_user_reading_locations_on_project_id", using: :btree
+  add_index "user_reading_locations", ["user_key", "project_id"], name: "index_user_reading_locations_on_user_key_and_project_id", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",               limit: 255, default: "", null: false

--- a/spec/controllers/site/published_notes_controller_spec.rb
+++ b/spec/controllers/site/published_notes_controller_spec.rb
@@ -21,5 +21,21 @@ RSpec.describe Site::PublishedNotesController, type: :controller do
       get :index, site_id: project.id
       expect(response_json[0].keys).to match_array(["id", "published_at", "html_title", "html_body"])
     end
+
+    context "with large pages" do
+      let!(:published_notes) { FactoryGirl.create_list(:note, 30, project: project, published: true) }
+
+      it "pages the request" do
+        get :index, site_id: project.id
+        expect(response_json.length).to eq(10)
+        expect(response_json[0]["id"]).to eq(published_notes.last.id)
+      end
+
+      it "pages the request" do
+        get :index, site_id: project.id, page: 2
+        expect(response_json.length).to eq(10)
+        expect(response_json[0]["id"]).to eq(published_notes[19].id)
+      end
+    end
   end
 end

--- a/spec/controllers/site/published_notes_controller_spec.rb
+++ b/spec/controllers/site/published_notes_controller_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Site::PublishedNotesController, type: :controller do
+  let!(:project) { FactoryGirl.create(:project) }
+
+  describe "GET index" do
+    let!(:published_notes) { FactoryGirl.create_list(:note, 3, project: project, published: true) }
+    let!(:unpublished_notes) { FactoryGirl.create_list(:note, 4, project: project) }
+
+    it "is successful" do
+      get :index, site_id: project.id
+      expect(response).to be_success
+    end
+
+    it "returns published notes" do
+      get :index, site_id: project.id
+      expect(response_json.length).to eq(3)
+    end
+
+    it "returns desired fields" do
+      get :index, site_id: project.id
+      expect(response_json[0].keys).to match_array(["id", "published_at", "html_title", "html_body"])
+    end
+  end
+end

--- a/spec/controllers/site/published_notes_controller_spec.rb
+++ b/spec/controllers/site/published_notes_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Site::PublishedNotesController, type: :controller do
         expect(UserReadingLocation.last.reading_location).to be_within(2).of(Time.current)
       end
 
-      context "with a reading_location later than the published_at" do
+      context "with a reading_location > published_at" do
         let!(:time) { 5.days.from_now }
         let!(:reading_location) { project.user_reading_locations.create!(user_key: "steve", reading_location: time) }
 
@@ -75,6 +75,18 @@ RSpec.describe Site::PublishedNotesController, type: :controller do
           expect {
             make_request!
           }.not_to change { reading_location.reload.attributes }
+        end
+      end
+
+      context "with a reading_location < published_at" do
+        let!(:time) { 5.minutes.ago }
+        before { Note.update_all(published_at: 4.minutes.ago) }
+        let!(:reading_location) { project.user_reading_locations.create!(user_key: "steve", reading_location: time) }
+
+        it "updates the reading_location" do
+          expect {
+            make_request!
+          }.to change { reading_location.reload.reading_location }.to be_within(2).of(4.minutes.ago)
         end
       end
     end

--- a/spec/controllers/site/published_notes_controller_spec.rb
+++ b/spec/controllers/site/published_notes_controller_spec.rb
@@ -100,17 +100,21 @@ RSpec.describe Site::PublishedNotesController, type: :controller do
   describe "GET unread" do
     let!(:published_notes) { FactoryGirl.create_list(:note, 3, project: project, published: true) }
     let!(:unpublished_notes) { FactoryGirl.create_list(:note, 4, project: project) }
+    let!(:reading_location) { project.user_reading_locations.create!(user_key: "steve", reading_location: 5.seconds.ago) }
 
     context "without a UserReadingLocation" do
-      it "returns all published notes" do
+      it "renders count of all published notes" do
+        get :unread, site_id: project.id, user_key: "test"
+        expect(response_json["unread"]).to eq(published_notes.count)
+      end
+
+      it "renders count of all published notes" do
         get :unread, site_id: project.id
         expect(response_json["unread"]).to eq(published_notes.count)
       end
     end
 
     context "with a UserReadingLocation" do
-      let!(:reading_location) { project.user_reading_locations.create!(user_key: "steve", reading_location: 5.seconds.ago) }
-
       it "renders the count of notes later than reading_location" do
         published_notes[0].update!(published_at: 5.minutes.ago)
         get :unread, site_id: project.id, user_key: "steve"

--- a/spec/controllers/site/published_notes_controller_spec.rb
+++ b/spec/controllers/site/published_notes_controller_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe Site::PublishedNotesController, type: :controller do
 
     context "with a user_key" do
       subject(:make_request!) { get :index, site_id: project.id, user_key: "steve" }
+      let!(:project2) { FactoryGirl.create(:project) }
+      let!(:reading_location) { project2.user_reading_locations.create!(user_key: "steve", reading_location: 5.minutes.from_now) }
 
       it "creates a new UserReadingLocation" do
         expect {

--- a/spec/controllers/site/published_notes_controller_spec.rb
+++ b/spec/controllers/site/published_notes_controller_spec.rb
@@ -29,6 +29,9 @@ RSpec.describe Site::PublishedNotesController, type: :controller do
 
       it "pages the request" do
         make_request!
+        expect(response_json["meta"]["total_count"]).to eq(30)
+        expect(response_json["meta"]["page"]).to eq(1)
+        expect(response_json["meta"]["total_pages"]).to eq(3)
         expect(response_json["notes"].length).to eq(10)
         expect(response_json["notes"][0]["id"]).to eq(published_notes.last.id)
       end

--- a/spec/controllers/site/published_notes_controller_spec.rb
+++ b/spec/controllers/site/published_notes_controller_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe Site::PublishedNotesController, type: :controller do
 
     it "returns published notes" do
       make_request!
-      expect(response_json.length).to eq(3)
+      expect(response_json["notes"].length).to eq(3)
     end
 
     it "returns desired fields" do
       make_request!
-      expect(response_json[0].keys).to match_array(["id", "published_at", "html_title", "html_body"])
+      expect(response_json["notes"][0].keys).to match_array(["id", "published_at", "html_title", "html_body"])
     end
 
     context "with large pages" do
@@ -29,14 +29,14 @@ RSpec.describe Site::PublishedNotesController, type: :controller do
 
       it "pages the request" do
         make_request!
-        expect(response_json.length).to eq(10)
-        expect(response_json[0]["id"]).to eq(published_notes.last.id)
+        expect(response_json["notes"].length).to eq(10)
+        expect(response_json["notes"][0]["id"]).to eq(published_notes.last.id)
       end
 
       it "pages the request" do
         get :index, site_id: project.id, page: 2
-        expect(response_json.length).to eq(10)
-        expect(response_json[0]["id"]).to eq(published_notes[19].id)
+        expect(response_json["notes"].length).to eq(10)
+        expect(response_json["notes"][0]["id"]).to eq(published_notes[19].id)
       end
     end
 

--- a/spec/controllers/site/published_notes_controller_spec.rb
+++ b/spec/controllers/site/published_notes_controller_spec.rb
@@ -7,18 +7,20 @@ RSpec.describe Site::PublishedNotesController, type: :controller do
     let!(:published_notes) { FactoryGirl.create_list(:note, 3, project: project, published: true) }
     let!(:unpublished_notes) { FactoryGirl.create_list(:note, 4, project: project) }
 
+    subject(:make_request!) { get :index, site_id: project.id }
+
     it "is successful" do
-      get :index, site_id: project.id
+      make_request!
       expect(response).to be_success
     end
 
     it "returns published notes" do
-      get :index, site_id: project.id
+      make_request!
       expect(response_json.length).to eq(3)
     end
 
     it "returns desired fields" do
-      get :index, site_id: project.id
+      make_request!
       expect(response_json[0].keys).to match_array(["id", "published_at", "html_title", "html_body"])
     end
 
@@ -26,7 +28,7 @@ RSpec.describe Site::PublishedNotesController, type: :controller do
       let!(:published_notes) { FactoryGirl.create_list(:note, 30, project: project, published: true) }
 
       it "pages the request" do
-        get :index, site_id: project.id
+        make_request!
         expect(response_json.length).to eq(10)
         expect(response_json[0]["id"]).to eq(published_notes.last.id)
       end
@@ -35,6 +37,45 @@ RSpec.describe Site::PublishedNotesController, type: :controller do
         get :index, site_id: project.id, page: 2
         expect(response_json.length).to eq(10)
         expect(response_json[0]["id"]).to eq(published_notes[19].id)
+      end
+    end
+
+    context "with a user_key" do
+      subject(:make_request!) { get :index, site_id: project.id, user_key: "steve" }
+
+      it "creates a new UserReadingLocation" do
+        expect {
+          make_request!
+        }.to change { project.user_reading_locations.count }.by(1)
+      end
+
+      it "uses an existing UserReadingLocation" do
+        project.user_reading_locations.create!(user_key: "steve", reading_location: Time.current)
+        expect {
+          make_request!
+        }.not_to change { project.user_reading_locations.count }
+      end
+
+      it "sets reading_location" do
+        make_request!
+        expect(UserReadingLocation.last.reading_location).to eq(published_notes.last.published_at)
+      end
+
+      it "uses the current  time if published_at is nil" do
+        Note.update_all(published_at: nil)
+        make_request!
+        expect(UserReadingLocation.last.reading_location).to be_within(2).of(Time.current)
+      end
+
+      context "with a reading_location later than the published_at" do
+        let!(:time) { 5.days.from_now }
+        let!(:reading_location) { project.user_reading_locations.create!(user_key: "steve", reading_location: time) }
+
+        it "doesn't update the reading_location" do
+          expect {
+            make_request!
+          }.not_to change { reading_location.reload.attributes }
+        end
       end
     end
   end

--- a/spec/controllers/site/published_notes_controller_spec.rb
+++ b/spec/controllers/site/published_notes_controller_spec.rb
@@ -96,4 +96,32 @@ RSpec.describe Site::PublishedNotesController, type: :controller do
       end
     end
   end
+
+  describe "GET unread" do
+    let!(:published_notes) { FactoryGirl.create_list(:note, 3, project: project, published: true) }
+    let!(:unpublished_notes) { FactoryGirl.create_list(:note, 4, project: project) }
+
+    context "without a UserReadingLocation" do
+      it "returns all published notes" do
+        get :unread, site_id: project.id
+        expect(response_json["unread"]).to eq(published_notes.count)
+      end
+    end
+
+    context "with a UserReadingLocation" do
+      let!(:reading_location) { project.user_reading_locations.create!(user_key: "steve", reading_location: 5.seconds.ago) }
+
+      it "renders the count of notes later than reading_location" do
+        published_notes[0].update!(published_at: 5.minutes.ago)
+        get :unread, site_id: project.id, user_key: "steve"
+        expect(response_json["unread"]).to eq(2)
+      end
+
+      it "renders the count of notes later than reading_location" do
+        Note.update_all(published_at: 5.minutes.ago)
+        get :unread, site_id: project.id, user_key: "steve"
+        expect(response_json["unread"]).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Feature - Site API

The Site API will provide a way for sites to build an API driven change log. It will keep track of user's reading locations, published notes, and will provide a way to query all of this.